### PR TITLE
snowflake-api: GET query support

### DIFF
--- a/snowflake-api/Cargo.toml
+++ b/snowflake-api/Cargo.toml
@@ -22,15 +22,16 @@ serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 url = "2"
 uuid = { version = "1.4", features = ["v4"] }
-arrow = "42"
+arrow = "45"
 base64 = "0.21"
 regex = "1"
-object_store = { version = "0.6", features = ["aws"] }
+object_store = { version = "0.7", features = ["aws"] }
 async-trait = "0.1"
 
 [dev-dependencies]
 anyhow = "1"
 pretty_env_logger = "0.5.0"
 clap = { version = "4", features = ["derive"] }
-arrow = { version = "42", features = ["prettyprint"] }
 tokio = { version = "1", features=["macros", "rt-multi-thread"] }
+parquet = { version = "45", features = ["arrow", "snap"] }
+arrow = { version = "45", features = ["prettyprint"] }

--- a/snowflake-api/src/responses.rs
+++ b/snowflake-api/src/responses.rs
@@ -198,18 +198,19 @@ pub struct PutGetResponseData {
     // file upload parallelism
     pub parallel: i32,
     // file size threshold, small ones are should be uploaded with given parallelism
-    pub threshold: i64,
+    pub threshold: Option<i64>,
     // doesn't need compression if source is already compressed
-    pub auto_compress: bool,
+    pub auto_compress: Option<bool>,
     pub overwrite: bool,
     // maps to one of the predefined compression algos
     // todo: support different compression formats?
-    pub source_compression: String,
+    pub source_compression: Option<String>,
     pub stage_info: PutGetStageInfo,
     pub encryption_material: EncryptionMaterialVariant,
     // GCS specific. If you request multiple files?
+    // might return a [ null ] for AWS responses
     #[serde(default)]
-    pub presigned_urls: Vec<String>,
+    pub presigned_urls: Vec<Option<String>>,
     #[serde(default)]
     pub parameters: Vec<NameValueParameter>,
     pub statement_type_id: Option<i64>,


### PR DESCRIPTION
- [ ] Implement client-side decryption for S3

Currently decryption headers are not supported by either popular S3 client, see https://github.com/apache/arrow-rs-object-store/issues/294 and https://github.com/durch/rust-s3/blob/7fdb685d71385152198f906068f15faaabd28592/s3/src/utils.rs#L140