### PR TITLE
Support fetching chunks

### DIFF
--- a/snowflake-api/Cargo.toml
+++ b/snowflake-api/Cargo.toml
@@ -14,7 +14,7 @@ license = "Apache-2.0"
 [dependencies]
 thiserror = "1"
 snowflake-jwt = "0.3.0"
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { version = "0.11", default-features = false, features = ["gzip", "rustls-tls", "json"] }
 reqwest-middleware = "0.2"
 reqwest-retry = "0.3"
 log = "0.4"
@@ -27,6 +27,8 @@ base64 = "0.21"
 regex = "1"
 object_store = { version = "0.7", features = ["aws"] }
 async-trait = "0.1"
+bytes = "1"
+futures = "0.3"
 
 [dev-dependencies]
 anyhow = "1"

--- a/snowflake-api/Cargo.toml
+++ b/snowflake-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snowflake-api"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Snowflake API bindings"
 authors = ["Andrew Korzhuev <korzhuev@andrusha.me>"]

--- a/snowflake-api/Cargo.toml
+++ b/snowflake-api/Cargo.toml
@@ -16,21 +16,21 @@ thiserror = "1"
 snowflake-jwt = "0.3.0"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json"] }
 reqwest-middleware = "0.2"
-reqwest-retry = "0.2"
+reqwest-retry = "0.3"
 log = "0.4"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 url = "2"
 uuid = { version = "1.4", features = ["v4"] }
-arrow = "42"
+arrow = "47"
 base64 = "0.21"
 regex = "1"
-object_store = { version = "0.6", features = ["aws"] }
+object_store = { version = "0.7", features = ["aws"] }
 async-trait = "0.1"
 
 [dev-dependencies]
 anyhow = "1"
 pretty_env_logger = "0.5.0"
 clap = { version = "4", features = ["derive"] }
-arrow = { version = "42", features = ["prettyprint"] }
+arrow = { version = "47", features = ["prettyprint"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/snowflake-api/src/connection.rs
+++ b/snowflake-api/src/connection.rs
@@ -115,9 +115,8 @@ impl Connection {
         let client_start_time = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
-            .as_secs();
-        let client_start_time = client_start_time.to_string();
-
+            .as_secs()
+            .to_string();
         // fixme: update uuid's on the retry
         let request_id = request_id.to_string();
         let request_guid = request_guid.to_string();

--- a/snowflake-api/src/lib.rs
+++ b/snowflake-api/src/lib.rs
@@ -281,18 +281,16 @@ impl SnowflakeApi {
         // if response was empty, base64 data is empty string
         // todo: still return empty arrow batch with proper schema? (schema always included)
         if resp.data.returned == 0 {
-            log::info!("Got response with 0 rows");
-
+            log::debug!("Got response with 0 rows");
             Ok(QueryResult::Empty)
         } else if let Some(json) = resp.data.rowset {
-            log::info!("Got JSON response");
-
+            log::debug!("Got JSON response");
             Ok(QueryResult::Json(json))
         } else if let Some(base64) = resp.data.rowset_base64 {
             // fixme: loads everything into memory
             let mut res = vec![];
             if !base64.is_empty() {
-                log::info!("Got base64 encoded response");
+                log::debug!("Got base64 encoded response");
                 let bytes = base64::engine::general_purpose::STANDARD.decode(base64)?;
                 let fr = StreamReader::try_new_unbuffered(bytes.to_byte_slice(), None)?;
                 for batch in fr {
@@ -332,7 +330,6 @@ impl SnowflakeApi {
             sequence_id: parts.sequence_id,
             is_internal: false,
         };
-        println!("{body:?}");
 
         let resp = self
             .connection

--- a/snowflake-api/src/lib.rs
+++ b/snowflake-api/src/lib.rs
@@ -285,6 +285,9 @@ impl SnowflakeApi {
             Ok(QueryResult::Empty)
         } else if let Some(json) = resp.data.rowset {
             log::debug!("Got JSON response");
+            // NOTE: json response could be chunked too. however, go clients should receive arrow by-default,
+            // unless user sets session variable to return json. This case was added for debugging and status
+            // information being passed through that fields.
             Ok(QueryResult::Json(json))
         } else if let Some(base64) = resp.data.rowset_base64 {
             // fixme: loads everything into memory

--- a/snowflake-api/src/lib.rs
+++ b/snowflake-api/src/lib.rs
@@ -332,6 +332,7 @@ impl SnowflakeApi {
             sequence_id: parts.sequence_id,
             is_internal: false,
         };
+        println!("{body:?}");
 
         let resp = self
             .connection

--- a/snowflake-api/src/session.rs
+++ b/snowflake-api/src/session.rs
@@ -225,10 +225,7 @@ impl Session {
             *auth_tokens = Some(tokens);
         }
         auth_tokens.as_mut().unwrap().sequence_id += 1;
-        let session_token_auth_header = format!(
-            "Snowflake Token=\"{}\"",
-            &auth_tokens.as_ref().unwrap().session_token.token
-        );
+        let session_token_auth_header = auth_tokens.as_ref().unwrap().session_token.auth_header();
         Ok(AuthParts {
             session_token_auth_header,
             sequence_id: auth_tokens.as_ref().unwrap().sequence_id,

--- a/snowflake-api/src/session.rs
+++ b/snowflake-api/src/session.rs
@@ -225,8 +225,12 @@ impl Session {
             *auth_tokens = Some(tokens);
         }
         auth_tokens.as_mut().unwrap().sequence_id += 1;
+        let session_token_auth_header = format!(
+            "Snowflake Token=\"{}\"",
+            &auth_tokens.as_ref().unwrap().session_token.token
+        );
         Ok(AuthParts {
-            session_token_auth_header: auth_tokens.as_ref().unwrap().session_token.token.clone(),
+            session_token_auth_header,
             sequence_id: auth_tokens.as_ref().unwrap().sequence_id,
         })
     }


### PR DESCRIPTION
This PR add support for fetching record batches which are served by Snowflake over multiple chunk files. In this case, snowflake sends some initial date via base64, and then a list of additional files via the `resp.data.chunks` field.

In addition, this PR fixes the authentication session header which was broken in a recent commit. This PR also makes the snowflake-rs API thread-safe so clients can issue concurrent requests.