### PR TITLE
Breaking Change: Make Warehouse Optional

### DIFF
--- a/snowflake-api/README.md
+++ b/snowflake-api/README.md
@@ -50,7 +50,7 @@ use snowflake_api::{QueryResult, SnowflakeApi};
 async fn run_query(sql: &str) -> Result<QueryResult> {
     let mut api = SnowflakeApi::with_password_auth(
         "ACCOUNT_IDENTIFIER",
-        "WAREHOUSE",
+        Some("WAREHOUSE"),
         Some("DATABASE"),
         Some("SCHEMA"),
         "USERNAME",
@@ -58,7 +58,7 @@ async fn run_query(sql: &str) -> Result<QueryResult> {
         "PASSWORD",
     )?;
     let res = api.exec(sql).await?;
-    
+
     Ok(res)
 }
 ```

--- a/snowflake-api/examples/filetransfer.rs
+++ b/snowflake-api/examples/filetransfer.rs
@@ -56,7 +56,7 @@ async fn main() -> Result<()> {
             let pem = fs::read_to_string(pkey)?;
             SnowflakeApi::with_certificate_auth(
                 &args.account_identifier,
-                &args.warehouse,
+                Some(&args.warehouse),
                 Some(&args.database),
                 Some(&args.schema),
                 &args.username,
@@ -66,7 +66,7 @@ async fn main() -> Result<()> {
         }
         (None, Some(pwd)) => SnowflakeApi::with_password_auth(
             &args.account_identifier,
-            &args.warehouse,
+            Some(&args.warehouse),
             Some(&args.database),
             Some(&args.schema),
             &args.username,

--- a/snowflake-api/examples/run_sql.rs
+++ b/snowflake-api/examples/run_sql.rs
@@ -69,7 +69,7 @@ async fn main() -> Result<()> {
             let pem = fs::read_to_string(pkey)?;
             SnowflakeApi::with_certificate_auth(
                 &args.account_identifier,
-                &args.warehouse,
+                Some(&args.warehouse),
                 Some(&args.database),
                 Some(&args.schema),
                 &args.username,
@@ -79,7 +79,7 @@ async fn main() -> Result<()> {
         }
         (None, Some(pwd)) => SnowflakeApi::with_password_auth(
             &args.account_identifier,
-            &args.warehouse,
+            Some(&args.warehouse),
             Some(&args.database),
             Some(&args.schema),
             &args.username,

--- a/snowflake-api/src/lib.rs
+++ b/snowflake-api/src/lib.rs
@@ -97,7 +97,7 @@ impl SnowflakeApi {
     /// Initialize object with password auth. Authentication happens on the first request.
     pub fn with_password_auth(
         account_identifier: &str,
-        warehouse: &str,
+        warehouse: Option<&str>,
         database: Option<&str>,
         schema: Option<&str>,
         username: &str,
@@ -128,7 +128,7 @@ impl SnowflakeApi {
     /// Initialize object with private certificate auth. Authentication happens on the first request.
     pub fn with_certificate_auth(
         account_identifier: &str,
-        warehouse: &str,
+        warehouse: Option<&str>,
         database: Option<&str>,
         schema: Option<&str>,
         username: &str,

--- a/snowflake-api/src/responses.rs
+++ b/snowflake-api/src/responses.rs
@@ -82,7 +82,7 @@ pub struct LoginResponseData {
 pub struct SessionInfo {
     pub database_name: Option<String>,
     pub schema_name: Option<String>,
-    pub warehouse_name: String,
+    pub warehouse_name: Option<String>,
     pub role_name: String,
 }
 
@@ -122,8 +122,8 @@ pub struct QueryExecResponseData {
     pub database_provider: Option<String>,
     pub final_database_name: Option<String>, // unused in .NET
     pub final_schema_name: Option<String>,
-    pub final_warehouse_name: String, // unused in .NET
-    pub final_role_name: String,      // unused in .NET
+    pub final_warehouse_name: Option<String>, // unused in .NET
+    pub final_role_name: String,              // unused in .NET
     // only present on SELECT queries
     pub number_of_binds: Option<i32>, // unused in .NET
     // todo: deserialize into enum


### PR DESCRIPTION
Queries like `SHOW TABLES IN ACCOUNT` are perfectly valid without a warehouse provided. 