### PR TITLE
Breaking Change: Make Certificate Authentication Code Optional

### DIFF
--- a/snowflake-api/Cargo.toml
+++ b/snowflake-api/Cargo.toml
@@ -11,9 +11,12 @@ categories = ["database", "api-bindings"]
 readme = "README.md"
 license = "Apache-2.0"
 
+[features]
+cert-auth = ["dep:snowflake-jwt"]
+
 [dependencies]
 thiserror = "1"
-snowflake-jwt = "0.3.0"
+snowflake-jwt = { version = "0.3.0", optional = true }
 reqwest = { version = "0.11", default-features = false, features = ["gzip", "rustls-tls", "json"] }
 reqwest-middleware = "0.2"
 reqwest-retry = "0.3"

--- a/snowflake-api/README.md
+++ b/snowflake-api/README.md
@@ -50,7 +50,7 @@ use snowflake_api::{QueryResult, SnowflakeApi};
 async fn run_query(sql: &str) -> Result<QueryResult> {
     let mut api = SnowflakeApi::with_password_auth(
         "ACCOUNT_IDENTIFIER",
-        "WAREHOUSE",
+        Some("WAREHOUSE"),
         Some("DATABASE"),
         Some("SCHEMA"),
         "USERNAME",
@@ -58,7 +58,7 @@ async fn run_query(sql: &str) -> Result<QueryResult> {
         "PASSWORD",
     )?;
     let res = api.exec(sql).await?;
-    
+
     Ok(res)
 }
 ```

--- a/snowflake-api/examples/filetransfer.rs
+++ b/snowflake-api/examples/filetransfer.rs
@@ -56,7 +56,7 @@ async fn main() -> Result<()> {
             let pem = fs::read_to_string(pkey)?;
             SnowflakeApi::with_certificate_auth(
                 &args.account_identifier,
-                &args.warehouse,
+                Some(&args.warehouse),
                 Some(&args.database),
                 Some(&args.schema),
                 &args.username,
@@ -66,7 +66,7 @@ async fn main() -> Result<()> {
         }
         (None, Some(pwd)) => SnowflakeApi::with_password_auth(
             &args.account_identifier,
-            &args.warehouse,
+            Some(&args.warehouse),
             Some(&args.database),
             Some(&args.schema),
             &args.username,

--- a/snowflake-api/examples/run_sql.rs
+++ b/snowflake-api/examples/run_sql.rs
@@ -69,7 +69,7 @@ async fn main() -> Result<()> {
             let pem = fs::read_to_string(pkey)?;
             SnowflakeApi::with_certificate_auth(
                 &args.account_identifier,
-                &args.warehouse,
+                Some(&args.warehouse),
                 Some(&args.database),
                 Some(&args.schema),
                 &args.username,
@@ -79,7 +79,7 @@ async fn main() -> Result<()> {
         }
         (None, Some(pwd)) => SnowflakeApi::with_password_auth(
             &args.account_identifier,
-            &args.warehouse,
+            Some(&args.warehouse),
             Some(&args.database),
             Some(&args.schema),
             &args.username,

--- a/snowflake-api/src/lib.rs
+++ b/snowflake-api/src/lib.rs
@@ -97,7 +97,7 @@ impl SnowflakeApi {
     /// Initialize object with password auth. Authentication happens on the first request.
     pub fn with_password_auth(
         account_identifier: &str,
-        warehouse: &str,
+        warehouse: Option<&str>,
         database: Option<&str>,
         schema: Option<&str>,
         username: &str,
@@ -128,7 +128,7 @@ impl SnowflakeApi {
     /// Initialize object with private certificate auth. Authentication happens on the first request.
     pub fn with_certificate_auth(
         account_identifier: &str,
-        warehouse: &str,
+        warehouse: Option<&str>,
         database: Option<&str>,
         schema: Option<&str>,
         username: &str,

--- a/snowflake-api/src/requests.rs
+++ b/snowflake-api/src/requests.rs
@@ -15,6 +15,7 @@ pub struct LoginRequest<T> {
 }
 
 pub type PasswordLoginRequest = LoginRequest<PasswordRequestData>;
+#[cfg(feature = "cert-auth")]
 pub type CertLoginRequest = LoginRequest<CertRequestData>;
 
 #[derive(Serialize, Debug)]

--- a/snowflake-api/src/responses.rs
+++ b/snowflake-api/src/responses.rs
@@ -82,7 +82,7 @@ pub struct LoginResponseData {
 pub struct SessionInfo {
     pub database_name: Option<String>,
     pub schema_name: Option<String>,
-    pub warehouse_name: String,
+    pub warehouse_name: Option<String>,
     pub role_name: String,
 }
 
@@ -122,8 +122,8 @@ pub struct QueryExecResponseData {
     pub database_provider: Option<String>,
     pub final_database_name: Option<String>, // unused in .NET
     pub final_schema_name: Option<String>,
-    pub final_warehouse_name: String, // unused in .NET
-    pub final_role_name: String,      // unused in .NET
+    pub final_warehouse_name: Option<String>, // unused in .NET
+    pub final_role_name: String,              // unused in .NET
     // only present on SELECT queries
     pub number_of_binds: Option<i32>, // unused in .NET
     // todo: deserialize into enum

--- a/snowflake-api/src/session.rs
+++ b/snowflake-api/src/session.rs
@@ -10,8 +10,9 @@ use crate::connection;
 use crate::connection::{Connection, QueryType};
 #[cfg(feature = "cert-auth")]
 use crate::requests::{CertLoginRequest, CertRequestData};
-use crate::requests::{ClientEnvironment, LoginRequest, LoginRequestCommon,
-    PasswordLoginRequest, PasswordRequestData, RenewSessionRequest, SessionParameters
+use crate::requests::{
+    ClientEnvironment, LoginRequest, LoginRequestCommon, PasswordLoginRequest, PasswordRequestData,
+    RenewSessionRequest, SessionParameters,
 };
 use crate::responses::AuthResponse;
 
@@ -118,7 +119,8 @@ pub struct Session {
     username: String,
     role: Option<String>,
     // This is not used with the certificate auth crate
-    #[allow(dead_code)] private_key_pem: Option<String>,
+    #[allow(dead_code)]
+    private_key_pem: Option<String>,
     password: Option<String>,
 }
 

--- a/snowflake-api/src/session.rs
+++ b/snowflake-api/src/session.rs
@@ -8,9 +8,10 @@ use thiserror::Error;
 
 use crate::connection;
 use crate::connection::{Connection, QueryType};
-use crate::requests::{
-    CertLoginRequest, CertRequestData, ClientEnvironment, LoginRequest, LoginRequestCommon,
-    PasswordLoginRequest, PasswordRequestData, RenewSessionRequest, SessionParameters,
+#[cfg(feature = "cert-auth")]
+use crate::requests::{CertLoginRequest, CertRequestData};
+use crate::requests::{ClientEnvironment, LoginRequest, LoginRequestCommon,
+    PasswordLoginRequest, PasswordRequestData, RenewSessionRequest, SessionParameters
 };
 use crate::responses::AuthResponse;
 
@@ -116,7 +117,8 @@ pub struct Session {
 
     username: String,
     role: Option<String>,
-    private_key_pem: Option<String>,
+    // This is not used with the certificate auth crate
+    #[allow(dead_code)] private_key_pem: Option<String>,
     password: Option<String>,
 }
 


### PR DESCRIPTION
The snowflake-jwt is only necessary if you are using certificate auth. Removing this dependencies removes 10 crates and saves about 700 KB.

For now I made cert-auth disabled by default, but we can enable it by default to make this no longer a breaking change.

Please merge #10 before merging this.