### PR TITLE
Enable cert-auth by-default

### DIFF
--- a/snowflake-api/Cargo.toml
+++ b/snowflake-api/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/mycelial/snowflake-rs"
 version = "0.6.0"
 
 [features]
+default = ["cert-auth"]
 cert-auth = ["dep:snowflake-jwt"]
 
 [dependencies]

--- a/snowflake-api/src/session.rs
+++ b/snowflake-api/src/session.rs
@@ -215,10 +215,11 @@ impl Session {
             let tokens = match self.auth_type {
                 AuthType::Certificate => {
                     log::info!("Starting session with certificate authentication");
-                    #[cfg(feature = "cert-auth")]
-                    return self.create(self.cert_request_body()?).await;
-                    #[cfg(not(feature = "cert-auth"))]
-                    return Err(AuthError::MissingCertificate);
+                    if cfg!(feature = "cert-auth") {
+                        self.create(self.cert_request_body()?).await
+                    } else {
+                        Err(AuthError::MissingCertificate)?
+                    }
                 }
                 AuthType::Password => {
                     log::info!("Starting session with password authentication");


### PR DESCRIPTION
It's reasonable to have most useful features enabled by-default, especially since the certificate auth is the recommended way instead of using password.