### PR TITLE
Lock crate in tracing example

### DIFF
--- a/snowflake-api/examples/tracing/Cargo.toml
+++ b/snowflake-api/examples/tracing/Cargo.toml
@@ -17,7 +17,7 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3"
 # use the same version of opentelemetry as the one used by snowflake-api
 tracing-opentelemetry = "0.22"
-opentelemetry-otlp = "*"
+opentelemetry-otlp = "0.14"
 opentelemetry = "0.21"
 opentelemetry_sdk = { version = "0.21", features = ["rt-tokio"] }
 reqwest-tracing = { version = "0.4", features = ["opentelemetry_0_21"] }


### PR DESCRIPTION
opentelemetry recently made new release, wildcard dependency no longer allow example to compile