### PR TITLE
Update Error handling & support async query 

### DIFF
--- a/snowflake-api/Cargo.toml
+++ b/snowflake-api/Cargo.toml
@@ -19,7 +19,7 @@ cert-auth = ["dep:snowflake-jwt"]
 polars = ["dep:polars-core", "dep:polars-io"]
 
 [dependencies]
-arrow = "47"
+arrow = "50"
 async-trait = "0.1"
 base64 = "0.21"
 bytes = "1"
@@ -46,7 +46,7 @@ polars-core = { version = ">=0.32", optional = true}
 
 [dev-dependencies]
 anyhow = "1"
-arrow = { version = "47", features = ["prettyprint"] }
+arrow = { version = "50", features = ["prettyprint"] }
 clap = { version = "4", features = ["derive"] }
 pretty_env_logger = "0.5"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/snowflake-api/Cargo.toml
+++ b/snowflake-api/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.6.0"
 cert-auth = ["dep:snowflake-jwt"]
 
 [dependencies]
-arrow = "50"
+arrow = "47"
 async-trait = "0.1"
 base64 = "0.21"
 bytes = "1"
@@ -39,7 +39,7 @@ uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 anyhow = "1"
-arrow = { version = "50", features = ["prettyprint"] }
+arrow = { version = "47", features = ["prettyprint"] }
 clap = { version = "4", features = ["derive"] }
 pretty_env_logger = "0.5"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/snowflake-api/examples/tracing/Cargo.toml
+++ b/snowflake-api/examples/tracing/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.79"
-arrow = { version = "50.0.0", features = ["prettyprint"] }
+arrow = { version = "47.0.0", features = ["prettyprint"] }
 dotenv = "0.15.0"
 snowflake-api = { path = "../../../snowflake-api" }
 

--- a/snowflake-api/src/connection.rs
+++ b/snowflake-api/src/connection.rs
@@ -81,11 +81,6 @@ pub struct Connection {
     client: ClientWithMiddleware,
 }
 
-pub enum Method {
-    Get,
-    Post,
-}
-
 impl Connection {
     pub fn new() -> Result<Self, ConnectionError> {
         let client = Self::default_client_builder()?;

--- a/snowflake-api/src/connection.rs
+++ b/snowflake-api/src/connection.rs
@@ -177,15 +177,15 @@ impl Connection {
             .send()
             .await?;
 
-        let raw_response = resp.text().await?;
+        Ok(resp.json::<R>().await?)
 
-        match serde_json::from_str::<R>(&raw_response) {
-            Ok(r) => Ok(r),
-            Err(e) => Err(ConnectionError::UnexpectedResponse {
-                source: e,
-                response: raw_response,
-            }),
-        }
+        // match response {
+        //     ConnectionError::Au,
+        //     Err(e) => Err(ConnectionError::UnexpectedResponse {
+        //         source: e,
+        //         response: raw_response,
+        //     }),
+        // }
     }
 
     pub async fn get_chunk(

--- a/snowflake-api/src/connection.rs
+++ b/snowflake-api/src/connection.rs
@@ -81,6 +81,11 @@ pub struct Connection {
     client: ClientWithMiddleware,
 }
 
+pub enum Method {
+    Get,
+    Post,
+}
+
 impl Connection {
     pub fn new() -> Result<Self, ConnectionError> {
         let client = Self::default_client_builder()?;
@@ -129,54 +134,62 @@ impl Connection {
         extra_get_params: &[(&str, &str)],
         auth: Option<&str>,
         body: impl serde::Serialize,
+        url_override: Option<&str>,
     ) -> Result<R, ConnectionError> {
         let context = query_type.query_context();
-
-        let request_id = Uuid::new_v4();
-        let request_guid = Uuid::new_v4();
-        let client_start_time = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs()
-            .to_string();
-        // fixme: update uuid's on the retry
-        let request_id = request_id.to_string();
-        let request_guid = request_guid.to_string();
-
-        let mut get_params = vec![
-            ("clientStartTime", client_start_time.as_str()),
-            ("requestId", request_id.as_str()),
-            ("request_guid", request_guid.as_str()),
-        ];
-        get_params.extend_from_slice(extra_get_params);
-
-        let url = format!(
-            "https://{}.snowflakecomputing.com/{}",
-            &account_identifier, context.path
-        );
-        let url = Url::parse_with_params(&url, get_params)?;
-
         let mut headers = HeaderMap::new();
 
         headers.append(
             header::ACCEPT,
             HeaderValue::from_static(context.accept_mime),
         );
+
+        let base_url = format!(
+            "https://{}.snowflakecomputing.com/{}",
+            &account_identifier, context.path
+        );
         if let Some(auth) = auth {
             let mut auth_val = HeaderValue::from_str(auth)?;
             auth_val.set_sensitive(true);
             headers.append(header::AUTHORIZATION, auth_val);
         }
+        let resp = match url_override {
+            None => {
+                let request_id = Uuid::new_v4();
+                let request_guid = Uuid::new_v4();
+                let client_start_time = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs()
+                    .to_string();
+                // fixme: update uuid's on the retry
+                let request_id = request_id.to_string();
+                let request_guid = request_guid.to_string();
 
-        // todo: persist client to use connection polling
-        let resp = self
-            .client
-            .post(url)
-            .headers(headers)
-            .json(&body)
-            .send()
-            .await?;
-
+                let mut get_params = vec![
+                    ("clientStartTime", client_start_time.as_str()),
+                    ("requestId", request_id.as_str()),
+                    ("request_guid", request_guid.as_str()),
+                ];
+                get_params.extend_from_slice(extra_get_params);
+                let url = Url::parse_with_params(&base_url, get_params)?;
+                self.client
+                    .post(url)
+                    .headers(headers)
+                    .json(&body)
+                    .send()
+                    .await?
+            }
+            Some(get_request_url) => {
+                let url = Url::parse(&base_url)?.join(get_request_url)?;
+                self.client
+                    .get(url)
+                    .headers(headers)
+                    .json(&body)
+                    .send()
+                    .await?
+            }
+        };
         if resp.status() == reqwest::StatusCode::FORBIDDEN {
             return Err(ConnectionError::InvalidAccountIdentifier(
                 account_identifier.to_string(),

--- a/snowflake-api/src/lib.rs
+++ b/snowflake-api/src/lib.rs
@@ -36,7 +36,7 @@ use responses::ExecResponse;
 use session::{AuthError, Session};
 
 use crate::connection::QueryType;
-use crate::requests::ExecRequest;
+use crate::requests::{EmptyRequest, ExecRequest};
 use crate::responses::{
     AwsPutGetStageInfo, ExecResponseRowType, PutGetExecResponse, PutGetStageInfo, SnowflakeType,
 };
@@ -475,7 +475,7 @@ impl SnowflakeApi {
             .await?;
         log::debug!("Got query response: {:?}", resp);
 
-        let resp = match resp {
+        let mut resp = match resp {
             // processable response
             ExecResponse::Query(qr) => Ok(qr),
             ExecResponse::PutGet(_) => Err(SnowflakeApiError::UnexpectedResponse),
@@ -485,9 +485,24 @@ impl SnowflakeApi {
             )),
         }?;
 
+        while resp.is_async() {
+            // TODO(harry): refactor to use exponential backoff polling
+            let url = resp.data.get_result_url.as_ref().unwrap();
+            resp = match self.poll::<ExecResponse>(&url).await? {
+                ExecResponse::Query(qr) => qr,
+                ExecResponse::PutGet(_) => return Err(SnowflakeApiError::UnexpectedResponse),
+                ExecResponse::Error(e) => {
+                    return Err(SnowflakeApiError::ApiError(
+                        e.data.error_code,
+                        e.message.unwrap_or_default(),
+                    ))
+                }
+            };
+        }
+
         // if response was empty, base64 data is empty string
         // todo: still return empty arrow batch with proper schema? (schema always included)
-        if resp.data.returned == 0 {
+        if resp.data.returned.unwrap() == 0 {
             log::debug!("Got response with 0 rows");
             Ok(RawQueryResult::Empty)
         } else if let Some(value) = resp.data.rowset {
@@ -497,7 +512,13 @@ impl SnowflakeApi {
             // information being passed through that fields.
             Ok(RawQueryResult::Json(JsonResult {
                 value,
-                schema: resp.data.rowtype.into_iter().map(Into::into).collect(),
+                schema: resp
+                    .data
+                    .rowtype
+                    .unwrap()
+                    .into_iter()
+                    .map(Into::into)
+                    .collect(),
             }))
         } else if let Some(base64) = resp.data.rowset_base64 {
             // fixme: is it possible to give streaming interface?
@@ -545,6 +566,29 @@ impl SnowflakeApi {
                 &[],
                 Some(&parts.session_token_auth_header),
                 body,
+                None,
+            )
+            .await?;
+
+        Ok(resp)
+    }
+
+    async fn poll<R: serde::de::DeserializeOwned>(
+        &self,
+        get_result_url: &str,
+    ) -> Result<R, SnowflakeApiError> {
+        log::debug!("Polling: {}", get_result_url);
+
+        let parts = self.session.get_token().await?;
+        let resp = self
+            .connection
+            .request::<R>(
+                QueryType::ArrowQuery,
+                &self.account_identifier,
+                &[],
+                Some(&parts.session_token_auth_header),
+                EmptyRequest {},
+                Some(get_result_url),
             )
             .await?;
 

--- a/snowflake-api/src/requests.rs
+++ b/snowflake-api/src/requests.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 
 #[derive(Serialize, Debug)]
-pub struct EmptyRequest {}
+pub struct EmptyRequest;
 
 #[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]

--- a/snowflake-api/src/requests.rs
+++ b/snowflake-api/src/requests.rs
@@ -1,6 +1,9 @@
 use serde::Serialize;
 
 #[derive(Serialize, Debug)]
+pub struct EmptyRequest {}
+
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ExecRequest {
     pub sql_text: String,

--- a/snowflake-api/src/responses.rs
+++ b/snowflake-api/src/responses.rs
@@ -61,9 +61,10 @@ pub struct ExecErrorResponseData {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthErrorResponseData {
-    pub age: i64,
-    pub error_code: String,
-    pub internal_error: bool,
+    pub age: Option<i64>,
+    pub error_code: Option<String>,
+    pub internal_error: Option<bool>,
+    pub next_action: Option<String>,
     pub authn_method: Option<String>,
 }
 

--- a/snowflake-api/src/responses.rs
+++ b/snowflake-api/src/responses.rs
@@ -11,6 +11,16 @@ pub enum ExecResponse {
     Error(ExecErrorResponse),
 }
 
+impl ExecResponse {
+    pub fn is_async(&self) -> bool {
+        match self {
+            ExecResponse::Query(query) => query.is_async(),
+            ExecResponse::PutGet(put_get) => put_get.is_async(),
+            ExecResponse::Error(_) => false,
+        }
+    }
+}
+
 // todo: add close session response, which should be just empty?
 #[allow(clippy::large_enum_variant)]
 #[derive(Deserialize, Debug)]
@@ -30,6 +40,12 @@ pub struct BaseRestResponse<D> {
     pub message: Option<String>,
     pub success: bool,
     pub data: D,
+}
+
+impl<D> BaseRestResponse<D> {
+    pub fn is_async(&self) -> bool {
+        self.code == Some("333333".to_owned()) || self.code == Some("333334".to_owned())
+    }
 }
 
 pub type PutGetExecResponse = BaseRestResponse<PutGetResponseData>;
@@ -118,8 +134,8 @@ pub struct RenewSessionResponseData {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryExecResponseData {
-    pub parameters: Vec<NameValueParameter>,
-    pub rowtype: Vec<ExecResponseRowType>,
+    // pub parameters: Vec<NameValueParameter>,
+    pub rowtype: Option<Vec<ExecResponseRowType>>,
     // default for non-SELECT queries
     // GET / PUT has their own response format
     pub rowset: Option<serde_json::Value>,
@@ -127,24 +143,24 @@ pub struct QueryExecResponseData {
     // default for all SELECT queries
     // is base64-encoded Arrow IPC payload
     pub rowset_base64: Option<String>,
-    pub total: i64,
-    pub returned: i64,    // unused in .NET
-    pub query_id: String, // unused in .NET
-    pub database_provider: Option<String>,
-    pub final_database_name: Option<String>, // unused in .NET
-    pub final_schema_name: Option<String>,
-    pub final_warehouse_name: Option<String>, // unused in .NET
-    pub final_role_name: String,              // unused in .NET
+    // pub total: i64,
+    pub returned: Option<i64>,    // unused in .NET
+    // pub query_id: String, // unused in .NET
+    // pub database_provider: Option<String>,
+    // pub final_database_name: Option<String>, // unused in .NET
+    // pub final_schema_name: Option<String>,
+    // pub final_warehouse_name: Option<String>, // unused in .NET
+    // pub final_role_name: String,              // unused in .NET
     // only present on SELECT queries
     pub number_of_binds: Option<i32>, // unused in .NET
     // todo: deserialize into enum
-    pub statement_type_id: i64,
-    pub version: i64,
+    // pub statement_type_id: i64,
+    // pub version: i64,
     // if response is chunked
     #[serde(default)] // soft-default to empty Vec if not present
     pub chunks: Vec<ExecResponseChunk>,
     // x-amz-server-side-encryption-customer-key, when chunks are present for download
-    pub qrmk: Option<String>,
+    // pub qrmk: Option<String>,
     #[serde(default)] // chunks are present
     pub chunk_headers: HashMap<String, String>,
     // when async query is run (ping pong request?)

--- a/snowflake-api/src/responses.rs
+++ b/snowflake-api/src/responses.rs
@@ -134,7 +134,7 @@ pub struct RenewSessionResponseData {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryExecResponseData {
-    // pub parameters: Vec<NameValueParameter>,
+    pub parameters: Option<Vec<NameValueParameter>>,
     pub rowtype: Option<Vec<ExecResponseRowType>>,
     // default for non-SELECT queries
     // GET / PUT has their own response format
@@ -143,24 +143,24 @@ pub struct QueryExecResponseData {
     // default for all SELECT queries
     // is base64-encoded Arrow IPC payload
     pub rowset_base64: Option<String>,
-    // pub total: i64,
+    pub total: Option<i64>,
     pub returned: Option<i64>,    // unused in .NET
-    // pub query_id: String, // unused in .NET
-    // pub database_provider: Option<String>,
-    // pub final_database_name: Option<String>, // unused in .NET
-    // pub final_schema_name: Option<String>,
-    // pub final_warehouse_name: Option<String>, // unused in .NET
-    // pub final_role_name: String,              // unused in .NET
+    pub query_id: Option<String>, // unused in .NET
+    pub database_provider: Option<String>,
+    pub final_database_name: Option<String>, // unused in .NET
+    pub final_schema_name: Option<String>,
+    pub final_warehouse_name: Option<String>, // unused in .NET
+    pub final_role_name: Option<String>,              // unused in .NET
     // only present on SELECT queries
     pub number_of_binds: Option<i32>, // unused in .NET
     // todo: deserialize into enum
-    // pub statement_type_id: i64,
-    // pub version: i64,
+    pub statement_type_id: Option<i64>,
+    pub version: Option<i64>,
     // if response is chunked
     #[serde(default)] // soft-default to empty Vec if not present
     pub chunks: Vec<ExecResponseChunk>,
     // x-amz-server-side-encryption-customer-key, when chunks are present for download
-    // pub qrmk: Option<String>,
+    pub qrmk: Option<String>,
     #[serde(default)] // chunks are present
     pub chunk_headers: HashMap<String, String>,
     // when async query is run (ping pong request?)

--- a/snowflake-api/src/responses.rs
+++ b/snowflake-api/src/responses.rs
@@ -134,7 +134,7 @@ pub struct RenewSessionResponseData {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryExecResponseData {
-    // pub parameters: Vec<NameValueParameter>,
+    pub parameters: Option<Vec<NameValueParameter>>,
     pub rowtype: Option<Vec<ExecResponseRowType>>,
     // default for non-SELECT queries
     // GET / PUT has their own response format
@@ -143,14 +143,14 @@ pub struct QueryExecResponseData {
     // default for all SELECT queries
     // is base64-encoded Arrow IPC payload
     pub rowset_base64: Option<String>,
-    // pub total: i64,
+    pub total: Option<i64>,
     pub returned: Option<i64>,    // unused in .NET
-    // pub query_id: String, // unused in .NET
-    // pub database_provider: Option<String>,
-    // pub final_database_name: Option<String>, // unused in .NET
-    // pub final_schema_name: Option<String>,
-    // pub final_warehouse_name: Option<String>, // unused in .NET
-    // pub final_role_name: String,              // unused in .NET
+    pub query_id: Option<String>, // unused in .NET
+    pub database_provider: Option<String>,
+    pub final_database_name: Option<String>, // unused in .NET
+    pub final_schema_name: Option<String>,
+    pub final_warehouse_name: Option<String>, // unused in .NET
+    pub final_role_name: Option<String>,              // unused in .NET
     // only present on SELECT queries
     pub number_of_binds: Option<i32>, // unused in .NET
     // todo: deserialize into enum

--- a/snowflake-api/src/responses.rs
+++ b/snowflake-api/src/responses.rs
@@ -61,7 +61,10 @@ pub struct ExecErrorResponseData {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthErrorResponseData {
-    pub authn_method: String,
+    pub age: i64,
+    pub error_code: String,
+    pub internal_error: bool,
+    pub authn_method: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/snowflake-api/src/session.rs
+++ b/snowflake-api/src/session.rs
@@ -260,6 +260,7 @@ impl Session {
                     &[("delete", "true")],
                     Some(&tokens.session_token.auth_header()),
                     serde_json::Value::default(),
+                    None,
                 )
                 .await?;
 
@@ -336,6 +337,7 @@ impl Session {
                 &get_params,
                 None,
                 body,
+                None,
             )
             .await?;
         log::debug!("Auth response: {:?}", resp);
@@ -397,6 +399,7 @@ impl Session {
                     &[],
                     Some(&auth),
                     body,
+                    None,
                 )
                 .await?;
 


### PR DESCRIPTION
Improve error handling
* Add new `ConnectionError` variants, new fields in `AuthErrorResponseData`
* Update error handling in for better error reports

Add support to handle async query response. For requests that take more than 45 secs to complete, Snowflake returns a `get_request_url` so that the actual query response need to be polled via `GET` requests. Each poll request can take up to 45 secs till the next poll starts.

Used a older version of [snowflake-connector-nodejs - libs/connection/statement.js](https://github.com/snowflakedb/snowflake-connector-nodejs/releases?page=6) as a reference for `is_async` method, a query is in progress if its response code is `33333` or `33334`
 