### PR TITLE
Support async query

### DIFF
--- a/snowflake-api/src/requests.rs
+++ b/snowflake-api/src/requests.rs
@@ -1,6 +1,9 @@
 use serde::Serialize;
 
 #[derive(Serialize, Debug)]
+pub struct EmptyRequest {}
+
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ExecRequest {
     pub sql_text: String,

--- a/snowflake-api/src/responses.rs
+++ b/snowflake-api/src/responses.rs
@@ -11,6 +11,16 @@ pub enum ExecResponse {
     Error(ExecErrorResponse),
 }
 
+impl ExecResponse {
+    pub fn is_async(&self) -> bool {
+        match self {
+            ExecResponse::Query(query) => query.is_async(),
+            ExecResponse::PutGet(put_get) => put_get.is_async(),
+            ExecResponse::Error(_) => false,
+        }
+    }
+}
+
 // todo: add close session response, which should be just empty?
 #[allow(clippy::large_enum_variant)]
 #[derive(Deserialize, Debug)]
@@ -30,6 +40,12 @@ pub struct BaseRestResponse<D> {
     pub message: Option<String>,
     pub success: bool,
     pub data: D,
+}
+
+impl<D> BaseRestResponse<D> {
+    pub fn is_async(&self) -> bool {
+        self.code == Some("333333".to_owned()) || self.code == Some("333334".to_owned())
+    }
 }
 
 pub type PutGetExecResponse = BaseRestResponse<PutGetResponseData>;

--- a/snowflake-api/src/responses.rs
+++ b/snowflake-api/src/responses.rs
@@ -114,8 +114,8 @@ pub struct RenewSessionResponseData {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryExecResponseData {
-    pub parameters: Vec<NameValueParameter>,
-    pub rowtype: Vec<ExecResponseRowType>,
+    pub parameters: Option<Vec<NameValueParameter>>,
+    pub rowtype: Option<Vec<ExecResponseRowType>>,
     // default for non-SELECT queries
     // GET / PUT has their own response format
     pub rowset: Option<serde_json::Value>,
@@ -123,19 +123,19 @@ pub struct QueryExecResponseData {
     // default for all SELECT queries
     // is base64-encoded Arrow IPC payload
     pub rowset_base64: Option<String>,
-    pub total: i64,
-    pub returned: i64,    // unused in .NET
-    pub query_id: String, // unused in .NET
+    pub total: Option<i64>,
+    pub returned: Option<i64>,    // unused in .NET
+    pub query_id: Option<String>, // unused in .NET
     pub database_provider: Option<String>,
     pub final_database_name: Option<String>, // unused in .NET
     pub final_schema_name: Option<String>,
     pub final_warehouse_name: Option<String>, // unused in .NET
-    pub final_role_name: String,              // unused in .NET
+    pub final_role_name: Option<String>,              // unused in .NET
     // only present on SELECT queries
     pub number_of_binds: Option<i32>, // unused in .NET
     // todo: deserialize into enum
-    pub statement_type_id: i64,
-    pub version: i64,
+    pub statement_type_id: Option<i64>,
+    pub version: Option<i64>,
     // if response is chunked
     #[serde(default)] // soft-default to empty Vec if not present
     pub chunks: Vec<ExecResponseChunk>,

--- a/snowflake-api/src/session.rs
+++ b/snowflake-api/src/session.rs
@@ -260,6 +260,7 @@ impl Session {
                     &[("delete", "true")],
                     Some(&tokens.session_token.auth_header()),
                     serde_json::Value::default(),
+                    None,
                 )
                 .await?;
 
@@ -336,6 +337,7 @@ impl Session {
                 &get_params,
                 None,
                 body,
+                None,
             )
             .await?;
         log::debug!("Auth response: {:?}", resp);
@@ -397,6 +399,7 @@ impl Session {
                     &[],
                     Some(&auth),
                     body,
+                    None,
                 )
                 .await?;
 


### PR DESCRIPTION
Add support to handle async query response. For requests that take more than 45 secs to complete, Snowflake returns a `get_request_url` so that the actual query response need to be polled via `GET` requests. Each poll request can take up to 45 secs till the next poll starts.

Used a older version of [snowflake-connector-nodejs - libs/connection/statement.js](https://github.com/snowflakedb/snowflake-connector-nodejs/releases?page=6) as a reference for `is_async` method, a query is in progress if its response code is `33333` or `33334`