### PR TITLE
Add support for async query response

### DIFF
--- a/snowflake-api/README.md
+++ b/snowflake-api/README.md
@@ -18,7 +18,7 @@ Since it does a lot of I/O the library is async-only, and currently has hard dep
 - [x] PUT support [example](./examples/filetransfer.rs)
 - [ ] GET support
 - [x] AWS integration
-- [ ] GCloud integration
+- [ ] `GCloud` integration
 - [ ] Azure integration
 - [x] Parallel uploading of small files
 - [x] Glob support for PUT (eg `*.csv`)

--- a/snowflake-api/src/connection.rs
+++ b/snowflake-api/src/connection.rs
@@ -31,7 +31,7 @@ pub enum ConnectionError {
 struct QueryContext {
     path: String,
     accept_mime: &'static str,
-    method: reqwest::Method
+    method: reqwest::Method,
 }
 
 pub enum QueryType {
@@ -175,20 +175,16 @@ impl Connection {
 
         // todo: persist client to use connection polling
         let resp = match context.method {
-            reqwest::Method::POST => self
-                .client
-                .post(url)
-                .headers(headers)
-                .json(&body)
-                .send()
-                .await?,
-            reqwest::Method::GET => self
-                .client
-                .get(url)
-                .headers(headers)
-                .send()
-                .await?,
-            _ => panic!("Unsupported method"),     
+            reqwest::Method::POST => {
+                self.client
+                    .post(url)
+                    .headers(headers)
+                    .json(&body)
+                    .send()
+                    .await?
+            }
+            reqwest::Method::GET => self.client.get(url).headers(headers).send().await?,
+            _ => panic!("Unsupported method"),
         };
         Ok(resp.json::<R>().await?)
     }

--- a/snowflake-api/src/lib.rs
+++ b/snowflake-api/src/lib.rs
@@ -407,6 +407,7 @@ impl SnowflakeApi {
 
         match resp {
             ExecResponse::Query(_) => Err(SnowflakeApiError::UnexpectedResponse),
+            ExecResponse::QueryAsync(_) => Err(SnowflakeApiError::UnexpectedResponse),
             ExecResponse::PutGet(pg) => put::put(pg).await,
             ExecResponse::Error(e) => Err(SnowflakeApiError::ApiError(
                 e.data.error_code,
@@ -430,14 +431,21 @@ impl SnowflakeApi {
     }
 
     async fn exec_arrow_raw(&self, sql: &str) -> Result<RawQueryResult, SnowflakeApiError> {
-        let resp = self
+        let mut resp = self
             .run_sql::<ExecResponse>(sql, QueryType::ArrowQuery)
             .await?;
         log::debug!("Got query response: {:?}", resp);
 
+        if let ExecResponse::QueryAsync(data) = &resp {
+            log::debug!("Got async exec response");
+            resp = self.get_async_exec_result(&data.data.get_result_url).await?;
+            log::debug!("Got result for async exec: {:?}", resp);
+        }
+
         let resp = match resp {
             // processable response
             ExecResponse::Query(qr) => Ok(qr),
+            ExecResponse::QueryAsync(_) => Err(SnowflakeApiError::UnexpectedResponse),
             ExecResponse::PutGet(_) => Err(SnowflakeApiError::UnexpectedResponse),
             ExecResponse::Error(e) => Err(SnowflakeApiError::ApiError(
                 e.data.error_code,
@@ -504,10 +512,38 @@ impl SnowflakeApi {
                 &self.account_identifier,
                 &[],
                 Some(&parts.session_token_auth_header),
-                body,
+                Some(body),
             )
             .await?;
 
         Ok(resp)
+    }
+
+    pub async fn get_async_exec_result(&self, query_result_url: &String) -> Result<ExecResponse, SnowflakeApiError>{
+        log::debug!("Getting async exec result: {}", query_result_url);
+
+        let mut delay = 1; // Initial delay of 1 second
+
+        loop {
+            let parts = self.session.get_token().await?;
+            let resp = self
+            .connection
+            .request::<ExecResponse>(
+                QueryType::ArrowQueryResult(query_result_url.to_string()),
+                &self.account_identifier,
+                &[],
+                Some(&parts.session_token_auth_header),
+                serde_json::Value::default()
+            )
+            .await?;
+
+            if let ExecResponse::QueryAsync(_) = &resp {
+                // simple exponential retry with a maximum wait time of 5 seconds
+                tokio::time::sleep(tokio::time::Duration::from_secs(delay)).await;
+                delay = (delay * 2).min(5); // cap delay to 5 seconds
+            } else {
+                return Ok(resp);
+            }
+        };
     }
 }

--- a/snowflake-api/src/responses.rs
+++ b/snowflake-api/src/responses.rs
@@ -13,7 +13,8 @@ pub enum ExecResponse {
 }
 
 // todo: add close session response, which should be just empty?
-#[allow(clippy::large_enum_variant)]
+// FIXME: dead_code
+#[allow(clippy::large_enum_variant, dead_code)]
 #[derive(Deserialize, Debug)]
 #[serde(untagged)]
 pub enum AuthResponse {
@@ -62,6 +63,8 @@ pub struct ExecErrorResponseData {
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
+// FIXME: dead_code
+#[allow(dead_code)]
 pub struct AuthErrorResponseData {
     pub authn_method: String,
 }
@@ -74,6 +77,8 @@ pub struct NameValueParameter {
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
+// FIXME
+#[allow(dead_code)]
 pub struct LoginResponseData {
     pub session_id: i64,
     pub token: String,
@@ -88,6 +93,8 @@ pub struct LoginResponseData {
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
+// FIXME: dead_code
+#[allow(dead_code)]
 pub struct SessionInfo {
     pub database_name: Option<String>,
     pub schema_name: Option<String>,
@@ -97,6 +104,8 @@ pub struct SessionInfo {
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
+// FIXME: dead_code
+#[allow(dead_code)]
 pub struct AuthenticatorResponseData {
     pub token_url: String,
     pub sso_url: String,
@@ -105,6 +114,8 @@ pub struct AuthenticatorResponseData {
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
+// FIXME: dead_code
+#[allow(dead_code)]
 pub struct RenewSessionResponseData {
     pub session_token: String,
     pub validity_in_seconds_s_t: i64,

--- a/snowflake-api/src/responses.rs
+++ b/snowflake-api/src/responses.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 #[serde(untagged)]
 pub enum ExecResponse {
     Query(QueryExecResponse),
+    QueryAsync(QueryAsyncExecResponse),
     PutGet(PutGetExecResponse),
     Error(ExecErrorResponse),
 }
@@ -34,6 +35,7 @@ pub struct BaseRestResponse<D> {
 
 pub type PutGetExecResponse = BaseRestResponse<PutGetResponseData>;
 pub type QueryExecResponse = BaseRestResponse<QueryExecResponseData>;
+pub type QueryAsyncExecResponse = BaseRestResponse<QueryAsyncExecResponseData>;
 pub type ExecErrorResponse = BaseRestResponse<ExecErrorResponseData>;
 pub type AuthErrorResponse = BaseRestResponse<AuthErrorResponseData>;
 pub type AuthenticatorResponse = BaseRestResponse<AuthenticatorResponseData>;
@@ -54,7 +56,7 @@ pub struct ExecErrorResponseData {
     pub pos: Option<i64>,
 
     // fixme: only valid for exec query response error? present in any exec query response?
-    pub query_id: String,
+    pub query_id: Option<String>,
     pub sql_state: String,
 }
 
@@ -149,6 +151,13 @@ pub struct QueryExecResponseData {
     pub result_ids: Option<String>,
     // `progressDesc`, and `queryAbortAfterSecs` are not used but exist in .NET
     // `sendResultTime`, `queryResultFormat`, `queryContext` also exist
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryAsyncExecResponseData {
+    pub query_id: String,
+    pub get_result_url: String,
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
Queries longer than 45s returns response as they were executed with `exec_async=true` parameter and needs additional logic to get result once it is available. PR adds async `ExecResponse::QueryAsync` response type and `get_async_exec_result` method to handle this case. Implementation is similar to Go ([reference](https://github.com/snowflakedb/gosnowflake/blob/master/async.go#L163))

>If `async` parameter is not specified or is set to false, a statement is executed and the results are returned if the execution is completed in 45 seconds. If the statement execution takes longer to complete, the statement handle is returned.https://docs.snowflake.com/en/developer-guide/sql-api/reference#query-parameters

Example response
```json
{
  "data" : {
  "queryId" : "01b41e53-0002-66e9-005e-e38700025036",
  "getResultUrl" : "/queries/01b41e53-0002-66e9-005e-e38700025036/result",
  "queryAbortsAfterSecs" : 300,
  "progressDesc" : null
},
  "code" : "333334",
  "message" : "Asynchronous execution in progress. Use provided query id to perform query monitoring and management.",
  "success" : true
}
```

