### PR TITLE
Handle invalid warehouse/account errors correctly

### DIFF
--- a/snowflake-api/src/responses.rs
+++ b/snowflake-api/src/responses.rs
@@ -63,7 +63,6 @@ pub struct ExecErrorResponseData {
 pub struct AuthErrorResponseData {
     pub authn_method: Option<String>,
     pub error_code: Option<String>,
-
 }
 
 #[derive(Deserialize, Debug)]

--- a/snowflake-api/src/responses.rs
+++ b/snowflake-api/src/responses.rs
@@ -61,7 +61,9 @@ pub struct ExecErrorResponseData {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthErrorResponseData {
-    pub authn_method: String,
+    pub authn_method: Option<String>,
+    pub error_code: Option<String>,
+
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
When `warehouse` or `account identifier` are invalid there is no `authn_method` field returned and the lib is unable to parse response as a result error message is very uninformative and hard to troubleshoot ('unable to parse response'.) 

Example response
```
{
  "data" : {
  "internalError" : false,
  "errorCode" : "390201",
  "age" : 0
},
  "code" : "390201",
  "message" : "The requested warehouse does not exist or not authorized.",
  "success" : false,
  "headers" : null
}
```

As AuthErrorResponseData is the last one in AuthResponse enum, it will be parsed last so it is safe to make the fields optional (tested).