### PR TITLE
Add streaming support for arrow batches

### DIFF
--- a/snowflake-api/Cargo.toml
+++ b/snowflake-api/Cargo.toml
@@ -21,6 +21,7 @@ polars = ["dep:polars-core", "dep:polars-io"]
 [dependencies]
 arrow = "51"
 async-trait = "0.1"
+async-stream = "0.3.5"
 base64 = "0.22"
 bytes = "1"
 futures = "0.3"

--- a/snowflake-api/src/polars.rs
+++ b/snowflake-api/src/polars.rs
@@ -26,6 +26,7 @@ impl RawQueryResult {
             RawQueryResult::Bytes(bytes) => dataframe_from_bytes(bytes),
             RawQueryResult::Json(json) => dataframe_from_json(&json),
             RawQueryResult::Empty => Ok(DataFrame::empty()),
+            RawQueryResult::Stream(_) => todo!(),
         }
     }
 }


### PR DESCRIPTION
PRs adds `exec_streamed` method that returns Arrow Batches via stream while downloading/converting response. This reduces memory usage for large datasets as the records can be processed by chunks and improves performance by giving access for already loaded records.
- Similar to Snowflake go driver `MAX_CHUNK_DOWNLOAD_WORKERS(10)` download workers are used: https://github.com/snowflakedb/gosnowflake/blob/master/rows.go#L22
- I originally made `RawQueryResult` to always return result via stream but then realized that there is a polars dependency that requires RawQueryResult in bytes as it can't use async functionality to convert stream to bytes (defines TryFrom that is always sync)
- With this change I was finally able to perform queries agains the very large `snowflake_sample_data.tpch_sf100` [dataset](https://docs.snowflake.com/en/user-guide/sample-data-tpch). 