### PR TITLE
Increase minimum polars-rs version to 0.41

### DIFF
--- a/snowflake-api/Cargo.toml
+++ b/snowflake-api/Cargo.toml
@@ -41,8 +41,8 @@ url = "2"
 uuid = { version = "1", features = ["v4"] }
 
 # polars-support
-polars-core = { version = ">=0.32", optional = true }
-polars-io = { version = ">=0.32", features = [
+polars-core = { version = ">=0.41", optional = true }
+polars-io = { version = ">=0.41", features = [
     "json",
     "ipc_streaming",
 ], optional = true }

--- a/snowflake-api/src/polars.rs
+++ b/snowflake-api/src/polars.rs
@@ -1,5 +1,5 @@
 use std::convert::TryFrom;
-
+use std::num::NonZeroUsize;
 use bytes::{Buf, Bytes};
 use polars_core::frame::DataFrame;
 use polars_io::ipc::IpcStreamReader;
@@ -37,7 +37,7 @@ fn dataframe_from_json(json_result: &JsonResult) -> Result<DataFrame, PolarsCast
     let reader = std::io::Cursor::new(json_string.as_bytes());
     let df = JsonReader::new(reader)
         .with_json_format(JsonFormat::Json)
-        .infer_schema_len(Some(5))
+        .infer_schema_len(NonZeroUsize::new(5))
         .finish()?;
     Ok(df)
 }

--- a/snowflake-api/src/polars.rs
+++ b/snowflake-api/src/polars.rs
@@ -1,5 +1,6 @@
 use std::convert::TryFrom;
 use std::num::NonZeroUsize;
+
 use bytes::{Buf, Bytes};
 use polars_core::frame::DataFrame;
 use polars_io::ipc::IpcStreamReader;


### PR DESCRIPTION
Increase the minimum polars-rs version to 0.41 and upgrade the `JsonReader` instantiation to account for the breaking changes in https://github.com/pola-rs/polars/pull/16770.

This fixes #48.