### PR TITLE
Bug fix - handle gzip'ed chunks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM rust:1.80.1
+#FROM rust:1.80.1
+FROM scratch
 
 WORKDIR /app_source/deps/snowflake-rs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+
+WORKDIR /app_source/deps/snowflake-rs/target
+
+COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM scratch
+FROM rust:1.80.1
 
-WORKDIR /app_source/deps/snowflake-rs/target
+WORKDIR /app_source/deps/snowflake-rs
 
 COPY . .

--- a/snowflake-api/Cargo.toml
+++ b/snowflake-api/Cargo.toml
@@ -51,6 +51,7 @@ polars-io = { version = ">=0.32", features = [
 glob = { version = "0.3" }
 object_store = { version = "0.11", features = ["aws"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+flate2 = "1.0.34"
 
 [dev-dependencies]
 anyhow = "1"


### PR DESCRIPTION
While the `reqwest` docs say that gzip compression is handled natively, my testing showed differently. Testing with a generic trial SF account was causing Arrow de-serialization errors for me. 