### PR TITLE
fix: Handling account_identifier before JWT token generation

### DIFF
--- a/snowflake-api/src/session.rs
+++ b/snowflake-api/src/session.rs
@@ -280,13 +280,7 @@ impl Session {
     fn cert_request_body(&self) -> Result<CertLoginRequest, AuthError> {
         // we want to strip region information from the account identifier
         // See: https://docs.snowflake.com/en/developer-guide/snowflake-rest-api/authentication#label-sfrest-api-jwt-token
-        let account = {
-            if self.account_identifier.contains(".global") {
-                self.account_identifier.split_once("-").unwrap().0
-            } else {
-                self.account_identifier.split_once(".").unwrap().0
-            }
-        };
+        let account = self.account_identifier.split_once(".").unwrap().0;
         let full_identifier = format!("{}.{}", &account, &self.username);
         let private_key_pem = self
             .private_key_pem

--- a/snowflake-api/src/session.rs
+++ b/snowflake-api/src/session.rs
@@ -278,7 +278,16 @@ impl Session {
 
     #[cfg(feature = "cert-auth")]
     fn cert_request_body(&self) -> Result<CertLoginRequest, AuthError> {
-        let full_identifier = format!("{}.{}", &self.account_identifier, &self.username);
+        // we want to strip region information from the account identifier
+        // See: https://docs.snowflake.com/en/developer-guide/snowflake-rest-api/authentication#label-sfrest-api-jwt-token
+        let account = {
+            if self.account_identifier.contains(".global") {
+                self.account_identifier.split_once("-").unwrap().0
+            } else {
+                self.account_identifier.split_once(".").unwrap().0
+            }
+        };
+        let full_identifier = format!("{}.{}", &account, &self.username);
         let private_key_pem = self
             .private_key_pem
             .as_ref()

--- a/snowflake-api/src/session.rs
+++ b/snowflake-api/src/session.rs
@@ -280,7 +280,7 @@ impl Session {
     fn cert_request_body(&self) -> Result<CertLoginRequest, AuthError> {
         // we want to strip region information from the account identifier
         // See: https://docs.snowflake.com/en/developer-guide/snowflake-rest-api/authentication#label-sfrest-api-jwt-token
-        let account = self.account_identifier.split_once(".").unwrap().0;
+        let account = self.account_identifier.split(".").next().unwrap_or(&self.account_identifier);
         let full_identifier = format!("{}.{}", &account, &self.username);
         let private_key_pem = self
             .private_key_pem


### PR DESCRIPTION
When using keypair authentication with snowflake, and when a JWT token is issued, the account identifier needs to have the region information stripped from it.
This PR aims to fix this issue, as currently, the whole account identifier is used as the issuer, which causes an invalid token to be generated.