### PR TITLE
deps: bump object_store to 0.13

### DIFF
--- a/snowflake-api/Cargo.toml
+++ b/snowflake-api/Cargo.toml
@@ -51,7 +51,7 @@ polars-io = { version = ">=0.41", features = [
 
 # put request support
 glob = { version = "0.3" }
-object_store = { version = "0.12", features = ["aws"] }
+object_store = { version = "0.13", features = ["aws"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [dev-dependencies]

--- a/snowflake-api/src/polars.rs
+++ b/snowflake-api/src/polars.rs
@@ -1,7 +1,8 @@
 use std::convert::TryFrom;
+use std::io::Cursor;
 use std::num::NonZeroUsize;
 
-use bytes::{Buf, Bytes};
+use bytes::Bytes;
 use polars_core::frame::DataFrame;
 use polars_io::ipc::IpcStreamReader;
 use polars_io::json::{JsonFormat, JsonReader};
@@ -76,7 +77,7 @@ fn arrays_to_objects(json_result: &JsonResult) -> Result<Value, PolarsCastError>
 fn dataframe_from_bytes(bytes: Vec<Bytes>) -> Result<DataFrame, PolarsCastError> {
     let mut df = DataFrame::empty();
     for b in bytes {
-        let df_chunk = IpcStreamReader::new(b.reader()).finish()?;
+        let df_chunk = IpcStreamReader::new(Cursor::new(b)).finish()?;
         df.vstack_mut(&df_chunk)?;
     }
     df.align_chunks();

--- a/snowflake-api/src/put.rs
+++ b/snowflake-api/src/put.rs
@@ -7,7 +7,7 @@ use futures::TryStreamExt;
 use object_store::aws::AmazonS3Builder;
 use object_store::limit::LimitStore;
 use object_store::local::LocalFileSystem;
-use object_store::ObjectStore;
+use object_store::{ObjectStore, ObjectStoreExt};
 use tokio::task;
 
 use crate::responses::{AwsPutGetStageInfo, PutGetExecResponse, PutGetStageInfo};


### PR DESCRIPTION
object_store 0.12 and below depend on `rustls-tempfile` which is now unmaintained (see https://rustsec.org/advisories/RUSTSEC-2025-0134).

This change bumps object_store to 0.13 which no longer depends on the unmaintained crate.

## Test plan

Locally ran:

```
cargo fmt
cargo clippy --all-targets --all-features -- -D warnings
cargo check
cargo build
cargo test
```